### PR TITLE
Performance improvements to iteration

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -480,13 +480,13 @@ func (t *BTree) newNode() (n *node) {
 
 func (t *BTree) freeNode(n *node) {
 	if len(t.freelist) < cap(t.freelist) {
-    for i := range n.items {
-      n.items[i] = nil  // clear to allow GC
-    }
+		for i := range n.items {
+			n.items[i] = nil // clear to allow GC
+		}
 		n.items = n.items[:0]
-    for i := range n.children {
-      n.children[i] = nil  // clear to allow GC
-    }
+		for i := range n.children {
+			n.children[i] = nil // clear to allow GC
+		}
 		n.children = n.children[:0]
 		t.freelist = append(t.freelist, n)
 	}

--- a/btree.go
+++ b/btree.go
@@ -355,15 +355,15 @@ func (n *node) growChildAndRemove(i int, item Item, minItems int, typ toRemove) 
 // values less than or equal to values 'to' returns true for, and 'to'
 // returns true for values greater than or equal to those that 'from'
 // does.
-func (n *node) iterateRange(from, to func(Item) bool, iter ItemIterator) bool {
+func (n *node) iterateRange(from, to Item, iter ItemIterator) bool {
 	for i, item := range n.items {
-		if !from(item) {
+		if item.Less(from) {
 			continue
 		}
 		if len(n.children) > 0 && !n.children[i].iterateRange(from, to, iter) {
 			return false
 		}
-		if !to(item) {
+		if !item.Less(to) {
 			return false
 		}
 		if !iter(item) {
@@ -378,9 +378,9 @@ func (n *node) iterateRange(from, to func(Item) bool, iter ItemIterator) bool {
 
 // iterateFrom provides a simple method for iterating over all elements in the
 // tree after a given item.
-func (n *node) iterateFrom(from func(Item) bool, iter ItemIterator) bool {
+func (n *node) iterateFrom(from Item, iter ItemIterator) bool {
 	for i, item := range n.items {
-		if !from(item) {
+		if item.Less(from) {
 			continue
 		}
 		if len(n.children) > 0 && !n.children[i].iterateFrom(from, iter) {
@@ -398,12 +398,12 @@ func (n *node) iterateFrom(from func(Item) bool, iter ItemIterator) bool {
 
 // iterateTo provides a simple method for iterating over all elements in the
 // tree before a given item.
-func (n *node) iterateTo(to func(Item) bool, iter ItemIterator) bool {
+func (n *node) iterateTo(to Item, iter ItemIterator) bool {
 	for i, item := range n.items {
 		if len(n.children) > 0 && !n.children[i].iterateTo(to, iter) {
 			return false
 		}
-		if !to(item) {
+		if !item.Less(to) {
 			return false
 		}
 		if !iter(item) {
@@ -556,10 +556,7 @@ func (t *BTree) AscendRange(greaterOrEqual, lessThan Item, iterator ItemIterator
 	if t.root == nil {
 		return
 	}
-	t.root.iterateRange(
-		func(a Item) bool { return !a.Less(greaterOrEqual) },
-		func(a Item) bool { return a.Less(lessThan) },
-		iterator)
+	t.root.iterateRange(greaterOrEqual, lessThan, iterator)
 }
 
 // AscendLessThan calls the iterator for every value in the tree within the range
@@ -568,9 +565,7 @@ func (t *BTree) AscendLessThan(pivot Item, iterator ItemIterator) {
 	if t.root == nil {
 		return
 	}
-	t.root.iterateTo(
-		func(a Item) bool { return a.Less(pivot) },
-		iterator)
+	t.root.iterateTo(pivot, iterator)
 }
 
 // AscendGreaterOrEqual calls the iterator for every value in the tree within
@@ -579,9 +574,7 @@ func (t *BTree) AscendGreaterOrEqual(pivot Item, iterator ItemIterator) {
 	if t.root == nil {
 		return
 	}
-	t.root.iterateFrom(
-		func(a Item) bool { return !a.Less(pivot) },
-		iterator)
+	t.root.iterateFrom(pivot, iterator)
 }
 
 // Ascend calls the iterator for every value in the tree within the range

--- a/btree.go
+++ b/btree.go
@@ -356,22 +356,24 @@ func (n *node) growChildAndRemove(i int, item Item, minItems int, typ toRemove) 
 // returns true for values greater than or equal to those that 'from'
 // does.
 func (n *node) iterateRange(from, to Item, iter ItemIterator) bool {
-	for i, item := range n.items {
-		if item.Less(from) {
-			continue
-		}
-		if len(n.children) > 0 && !n.children[i].iterateRange(from, to, iter) {
+	ilen := len(n.items)
+	clen := len(n.children)
+	index, _ := n.items.find(from)
+
+	for index < ilen {
+		if clen > 0 && !n.children[index].iterateRange(from, to, iter) {
 			return false
 		}
-		if !item.Less(to) {
+		if !n.items[index].Less(to) {
 			return false
 		}
-		if !iter(item) {
+		if !iter(n.items[index]) {
 			return false
 		}
+		index++
 	}
-	if len(n.children) > 0 {
-		return n.children[len(n.children)-1].iterateRange(from, to, iter)
+	if clen > 0 {
+		return n.children[clen-1].iterateRange(from, to, iter)
 	}
 	return true
 }
@@ -379,19 +381,21 @@ func (n *node) iterateRange(from, to Item, iter ItemIterator) bool {
 // iterateFrom provides a simple method for iterating over all elements in the
 // tree after a given item.
 func (n *node) iterateFrom(from Item, iter ItemIterator) bool {
-	for i, item := range n.items {
-		if item.Less(from) {
-			continue
-		}
-		if len(n.children) > 0 && !n.children[i].iterateFrom(from, iter) {
+	ilen := len(n.items)
+	clen := len(n.children)
+	index, _ := n.items.find(from)
+
+	for index < ilen {
+		if clen > 0 && !n.children[index].iterateFrom(from, iter) {
 			return false
 		}
-		if !iter(item) {
+		if !iter(n.items[index]) {
 			return false
 		}
+		index++
 	}
-	if len(n.children) > 0 {
-		return n.children[len(n.children)-1].iterateFrom(from, iter)
+	if clen > 0 {
+		return n.children[clen-1].iterateFrom(from, iter)
 	}
 	return true
 }


### PR DESCRIPTION
Created a few more iterators to be used by the public interface for performance improvements. I did this in two commits, the second one changes the private interface signatures from funcs (technically same signature as ItemIterator) to Item, but since the public interface never actually exposes funcs for ascending I figured this would be okay.

Before:
```
~/.../github.com/cstockton/gbtree$ go test -test.bench=.*
1
PASS
BenchmarkInsert	 3000000	       411 ns/op
BenchmarkDelete	 3000000	       424 ns/op
BenchmarkGet	 5000000	       363 ns/op
BenchmarkIterateAscend	    3000	    474049 ns/op
BenchmarkIterateAscendLessThan	    5000	    274409 ns/op
BenchmarkIterateAscendGreaterOrEqual	    5000	    277208 ns/op
BenchmarkIterateAscendRange	   10000	    216873 ns/op
ok  	github.com/cstockton/gbtree	16.429s
```

After:
```
~/.../github.com/cstockton/btree$ go test -test.bench=.*
1
PASS
BenchmarkInsert	 3000000	       408 ns/op
BenchmarkDelete	 3000000	       422 ns/op
BenchmarkGet	 5000000	       360 ns/op
BenchmarkIterateAscend	    3000	    431754 ns/op
BenchmarkIterateAscendLessThan	    5000	    257723 ns/op
BenchmarkIterateAscendGreaterOrEqual	    5000	    257560 ns/op
BenchmarkIterateAscendRange	   10000	    205764 ns/op
ok  	github.com/cstockton/btree	15.984s
```