### PR TITLE
Expose FreeList

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -90,6 +90,7 @@ func (f *FreeList) newNode(t *BTree) (n *node) {
 		return &node{t: t}
 	}
 	f.freelist, n = f.freelist[:index], f.freelist[index]
+	n.t = t
 	return
 }
 
@@ -103,6 +104,7 @@ func (f *FreeList) freeNode(n *node) {
 			n.children[i] = nil // clear to allow GC
 		}
 		n.children = n.children[:0]
+		n.t = nil // clear to allow GC
 		f.freelist = append(f.freelist, n)
 	}
 }

--- a/btree.go
+++ b/btree.go
@@ -64,6 +64,49 @@ type Item interface {
 	Less(than Item) bool
 }
 
+// FreeList represents a free list of btree nodes. By default each
+// BTree has its own FreeList, but multiple BTrees can share the same
+// FreeList.
+type FreeList struct {
+	freelist []*node
+	grow     bool
+}
+
+func NewFreeList() *FreeList {
+	return newFreeList(true)
+}
+
+func newDefaultFreeList() *FreeList {
+	return newFreeList(false)
+}
+
+func newFreeList(grow bool) *FreeList {
+	return &FreeList{freelist: make([]*node, 0, 32), grow: grow}
+}
+
+func (f *FreeList) newNode(t *BTree) (n *node) {
+	index := len(f.freelist) - 1
+	if index < 0 {
+		return &node{t: t}
+	}
+	f.freelist, n = f.freelist[:index], f.freelist[index]
+	return
+}
+
+func (f *FreeList) freeNode(n *node) {
+	if f.grow || len(f.freelist) < cap(f.freelist) {
+		for i := range n.items {
+			n.items[i] = nil // clear to allow GC
+		}
+		n.items = n.items[:0]
+		for i := range n.children {
+			n.children[i] = nil // clear to allow GC
+		}
+		n.children = n.children[:0]
+		f.freelist = append(f.freelist, n)
+	}
+}
+
 // ItemIterator allows callers of Ascend* to iterate in-order over portions of
 // the tree.  When this function returns false, iteration will stop and the
 // associated Ascend* function will immediately return.
@@ -74,12 +117,17 @@ type ItemIterator func(i Item) bool
 // New(2), for example, will create a 2-3-4 tree (each node contains 1-3 items
 // and 2-4 children).
 func New(degree int) *BTree {
+	return NewWithFreeList(degree, newDefaultFreeList())
+}
+
+// NewWithFreeList creates a new B-Tree that uses the given node free list.
+func NewWithFreeList(degree int, f *FreeList) *BTree {
 	if degree <= 1 {
 		panic("bad degree")
 	}
 	return &BTree{
 		degree:   degree,
-		freelist: make([]*node, 0, 32),
+		freelist: f,
 	}
 }
 
@@ -396,7 +444,7 @@ type BTree struct {
 	degree   int
 	length   int
 	root     *node
-	freelist []*node
+	freelist *FreeList
 }
 
 // maxItems returns the max number of items to allow per node.
@@ -410,27 +458,12 @@ func (t *BTree) minItems() int {
 	return t.degree - 1
 }
 
-func (t *BTree) newNode() (n *node) {
-	index := len(t.freelist) - 1
-	if index < 0 {
-		return &node{t: t}
-	}
-	t.freelist, n = t.freelist[:index], t.freelist[index]
-	return
+func (t *BTree) newNode() *node {
+	return t.freelist.newNode(t)
 }
 
 func (t *BTree) freeNode(n *node) {
-	if len(t.freelist) < cap(t.freelist) {
-    for i := range n.items {
-      n.items[i] = nil  // clear to allow GC
-    }
-		n.items = n.items[:0]
-    for i := range n.children {
-      n.children[i] = nil  // clear to allow GC
-    }
-		n.children = n.children[:0]
-		t.freelist = append(t.freelist, n)
-	}
+	t.freelist.freeNode(n)
 }
 
 // ReplaceOrInsert adds the given item to the tree.  If an item in the tree


### PR DESCRIPTION
This change allows multiple btrees to share the same node freelist rather than each btree having its own node freelist. 

We are developing an application that uses 32 GB of memory. Because of the amount of memory that we use we want the memory footprint of our application to change very little. Therefore, we make special effort to pre-allocate what we need at application startup and use free lists to reuse memory rather than allocating memory as we go and relying on the garbage collector to free memory.

I was delighted to discover that this btree package uses freelists to provide some relief for the GC. However, our application consists of two btrees. As our application runs, we are constantly moving thousands of btree items at a time between the two btrees. At the beginning, one of the btrees has all the items while the second btree has none. Sometime later, the second btree may have all the items while the first btree has none. Sometimes, the items may be split up evenly between the two btrees. The sum of the sizes of the 2 btrees always remains constant.

If each btree has its own free list, we would still have to allocate large amounts of space off the heap for the second btree as it acquires items for the first time. Moreover, the current freelists are limited in size to 32 btree nodes which is too small for our application. 

By having our two btrees share the same freelist we put even less strain on the GC.  As the first btree gives up items, it places nodes on the common freelist. The second btree can reuse the old nodes from the first btree rather than allocating new ones which means fewer heap allocations and less strain on the GC.

We understand that a separate freelist for each btree suffices for most applications, but in our particular case, we benefit from having our two btrees share the same freelist which is what this pull request allows.

Thank you in advance for considering this pull request.