### PR TITLE
Fix memory leak in removeAt methods.

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -138,8 +138,8 @@ func (s *items) insertAt(index int, item Item) {
 // back.
 func (s *items) removeAt(index int) Item {
 	item := (*s)[index]
-	(*s)[index] = nil
 	copy((*s)[index:], (*s)[index+1:])
+	(*s)[len(*s)-1] = nil
 	*s = (*s)[:len(*s)-1]
 	return item
 }
@@ -183,8 +183,8 @@ func (s *children) insertAt(index int, n *node) {
 // back.
 func (s *children) removeAt(index int) *node {
 	n := (*s)[index]
-	(*s)[index] = nil
 	copy((*s)[index:], (*s)[index+1:])
+	(*s)[len(*s)-1] = nil
 	*s = (*s)[:len(*s)-1]
 	return n
 }


### PR DESCRIPTION
This change sets the last item in the slice to nil before the slice length is decreased when removing arbitrary elements. In the writeup below vertical bars denote that beginning and end of the visible part of the slice. Items beyond the last vertical bar denote items that lie beyond the end of the slice yet are still within the slice's capacity and therefore cannot be garbage collected.

Before this change, deleting B from | A B C D E | yielded | A C D E | E
Then deleting E yielded | A C D | nil E.  Even though E is deleted, E can't be garbage collected because a copy of it still sits beyond the end of the slice yet within the slice's capacity.

With this change, deleting B from | A B C D E | yields | A C D E | nil so that no extra copies of items or child pointers exist beyond the end of the slice allowing them to be GCed.