### PR TITLE
Persistent12

### DIFF
--- a/btree_test.go
+++ b/btree_test.go
@@ -721,6 +721,24 @@ func TestDescendGreaterThan(t *testing.T) {
 
 const benchmarkTreeSize = 10000
 
+func BenchmarkCopy(b *testing.B) {
+	b.StopTimer()
+	insert := perm(benchmarkTreeSize)
+	builder := New(*btreeDegree)
+	for _, item := range insert {
+		builder.ReplaceOrInsert(item)
+	}
+	b.StartTimer()
+	i := 0
+	for i < b.N {
+		tr := builder.Copy()
+		i++
+		if tr.Len() != benchmarkTreeSize {
+			panic(tr.Len())
+		}
+	}
+}
+
 func BenchmarkInsert(b *testing.B) {
 	b.StopTimer()
 	insertP := perm(benchmarkTreeSize)


### PR DESCRIPTION
This is ImmutableBTree without the Builder class. The API changes here involve the following:
- Addition of ImmutableBTree class
- New Set() method on BTree
- New Copy() method on BTree (replaces Build in old Builder class)
- CopyOf() factory method to get a BTree from an ImmutableBTree.

As I had expected, the ImmutableInsert1 benchmark slowed down 2X from my previous PR but ImmutableInsert100 was only ~50% slower. ImmutableDelete gave similar results.

I suspect that ImmutableInsert100 was only 50% slower because with more changes, the changes themselves take up a larger percentage of time than the copying because the later changes require copying fewer nodes since the BTree  owns the nodes from the previous changes.

Although this PR does not have the performance that the previous PR had when changing Immutable trees, I prefer this PR to the previous one because the API is simpler. I believe that the 50% to 2X slow down in performance is a fair trade off for simpler API.
