### PR TITLE
Small patch to allow resetting the btree.

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -298,6 +298,20 @@ func (n *node) maybeSplitChild(i, maxItems int) bool {
 	return true
 }
 
+// reset will free all nodes within the given cow ctx.
+func (n *node) reset(c *copyOnWriteContext) {
+	for i := len(n.items) - 1; i >= 0; i-- {
+		if len(n.children) > 0 {
+			n.children[i+1].reset(c)
+		}
+	}
+	if len(n.children) > 0 {
+		n.children[0].reset(c)
+	} else {
+		c.freeNode(n)
+	}
+}
+
 // insert inserts an item into the subtree rooted at this node, making sure
 // no nodes in the subtree exceed maxItems items.  Should an equivalent item be
 // be found/replaced by insert, it will be returned.
@@ -616,6 +630,20 @@ func (t *BTree) Clone() (t2 *BTree) {
 	t.cow = &cow1
 	out.cow = &cow2
 	return &out
+}
+
+// Reset removes all items from the btree.
+func (t *BTree) Reset() {
+	if t.root == nil || len(t.root.items) == 0 {
+		return
+	}
+	t.root = t.root.mutableFor(t.cow)
+	t.root.reset(t.cow)
+	for _, n := range t.root.children {
+		t.cow.freeNode(n)
+	}
+	t.cow.freeNode(t.root)
+	t.root, t.length = nil, 0
 }
 
 // maxItems returns the max number of items to allow per node.

--- a/btree_test.go
+++ b/btree_test.go
@@ -431,6 +431,48 @@ func BenchmarkDelete(b *testing.B) {
 	}
 }
 
+func BenchmarkDeleteAll(b *testing.B) {
+	b.StopTimer()
+	insertP := perm(benchmarkTreeSize)
+	b.StartTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tr := New(*btreeDegree)
+		for _, v := range insertP {
+			tr.ReplaceOrInsert(v)
+		}
+
+		dels := make([]Item, 0, tr.Len())
+		tr.Ascend(ItemIterator(func(b Item) bool {
+			dels = append(dels, b)
+			return true
+		}))
+		for _, del := range dels {
+			tr.Delete(del)
+		}
+		if tr.Len() > 0 {
+			b.Fatal(`len must be zero`)
+		}
+	}
+}
+
+func BenchmarkReset(b *testing.B) {
+	b.StopTimer()
+	insertP := perm(benchmarkTreeSize)
+	b.StartTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tr := New(*btreeDegree)
+		for _, v := range insertP {
+			tr.ReplaceOrInsert(v)
+		}
+		tr.Reset()
+		if tr.Len() > 0 {
+			b.Fatal(`len must be zero`)
+		}
+	}
+}
+
 func BenchmarkGet(b *testing.B) {
 	b.StopTimer()
 	insertP := perm(benchmarkTreeSize)


### PR DESCRIPTION
I am serializing snapshots of the btree to be restored later. For saving I only need a read lock, for restoring I obtain a write lock on the tree. I was able to amortize all the costs of serialization and cheapen the restore process with a generous free list capacity. For larger restores the process of removing all the items from an existing tree is taxing. You have to visit N nodes to store in a temporary list (I cached this and reset[0:0] each restore), then iterate the temporary list to make N calls to delete.

I tried some other possibility such as creating an entirely new tree and replace the existing one, but without first deleting all the items in the tree my FreeList is empty so the allocations kill me instead. I could probably work around this with rotating between two trees and deleting in the background, but this would be much simpler if accepted. It provides around 2.5-3x speedup for removing all items from a btree and lowers my latency below the downstream tick rate. 

Small note: I included "Inserts" in the benchmarks because I was running into that issue that pops up sometimes with the benchmark timers where it runs forever on the Reset() test otherwise and I nothing I tried fixed it.

BenchmarkDeleteAll-24    	     100	  11680090 ns/op	  523832 B/op	     709 allocs/op
BenchmarkReset-24        	     300	   6648212 ns/op	  367997 B/op	     723 allocs/op


This patch provides around a 3 time speed up for my restore process