### PR TITLE
 Improve the iterate seek to O(logN)

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -500,13 +500,14 @@ const (
 // thus creating a "greaterOrEqual" or "lessThanEqual" rather than just a
 // "greaterThan" or "lessThan" queries.
 func (n *node) iterate(dir direction, start, stop Item, includeStart bool, hit bool, iter ItemIterator) (bool, bool) {
-	var ok bool
+	var ok, found bool
+	var index int
 	switch dir {
 	case ascend:
-		for i := 0; i < len(n.items); i++ {
-			if start != nil && n.items[i].Less(start) {
-				continue
-			}
+		if start != nil {
+			index, _ = n.items.find(start)
+		}
+		for i := index; i < len(n.items); i++ {
 			if len(n.children) > 0 {
 				if hit, ok = n.children[i].iterate(dir, start, stop, includeStart, hit, iter); !ok {
 					return hit, false
@@ -530,7 +531,15 @@ func (n *node) iterate(dir direction, start, stop Item, includeStart bool, hit b
 			}
 		}
 	case descend:
-		for i := len(n.items) - 1; i >= 0; i-- {
+		if start != nil {
+			index, found = n.items.find(start)
+			if !found {
+				index = index - 1
+			}
+		} else {
+			index = len(n.items) - 1
+		}
+		for i := index; i >= 0; i-- {
 			if start != nil && !n.items[i].Less(start) {
 				if !includeStart || hit || start.Less(n.items[i]) {
 					continue

--- a/btree_test.go
+++ b/btree_test.go
@@ -361,6 +361,21 @@ func BenchmarkInsert(b *testing.B) {
 	}
 }
 
+func BenchmarkSeek(b *testing.B) {
+	b.StopTimer()
+	size := 100000
+	insertP := perm(size)
+	tr := New(*btreeDegree)
+	for _, item := range insertP {
+		tr.ReplaceOrInsert(item)
+	}
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		tr.AscendGreaterOrEqual(Int(i%size), func(i Item) bool { return false })
+	}
+}
+
 func BenchmarkDeleteInsert(b *testing.B) {
 	b.StopTimer()
 	insertP := perm(benchmarkTreeSize)


### PR DESCRIPTION
Hi, In our scenario, we frequently use the iterate, and the `Less` compare is expenses when key is large.   This PR mainly improve the iterate location. uses binary search to quickly locates the start item.
before:
```
BenchmarkSeek-4          3000000               452 ns/op
BenchmarkSeek-4          3000000               513 ns/op
BenchmarkSeek-4          3000000               454 ns/op
BenchmarkSeek-4          3000000               450 ns/op
```
after:
```
BenchmarkSeek-4         10000000               225 ns/op
BenchmarkSeek-4         10000000               222 ns/op
BenchmarkSeek-4         10000000               223 ns/op
BenchmarkSeek-4         10000000               224 ns/op
```
