### PR TITLE
seperate copyright notice from go.mod body

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 module github.com/google/btree
 
 go 1.12


### PR DESCRIPTION
as was suggested after #30 merged, there should be separation between the license and the body