### PR TITLE
Minor documentation fix

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -796,7 +796,7 @@ func (t *BTree) DescendLessOrEqual(pivot Item, iterator ItemIterator) {
 }
 
 // DescendGreaterThan calls the iterator for every value in the tree within
-// the range (pivot, last], until iterator returns false.
+// the range [last, pivot), until iterator returns false.
 func (t *BTree) DescendGreaterThan(pivot Item, iterator ItemIterator) {
 	if t.root == nil {
 		return


### PR DESCRIPTION
DescendGreaterThan starts with the last item in the tree and descends to the least item greater than the pivot