### PR TITLE
fix: add GoLLRB dependency in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@
 module github.com/google/btree
 
 go 1.18
+
+require github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 // indirect


### PR DESCRIPTION
hi, 
Is it possible to add the dependency of the llrb package ?
because use this component in btree_mem.go 