### PR TITLE
fix: remove item may changed clone btree; (i+1) children has new cow,…

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -479,7 +479,7 @@ func (n *node) growChildAndRemove(i int, item Item, minItems int, typ toRemove) 
 		child := n.mutableChild(i)
 		// merge with right child
 		mergeItem := n.items.removeAt(i)
-		mergeChild := n.children.removeAt(i + 1)
+		mergeChild := n.children.removeAt(i + 1).mutableFor(n.cow)
 		child.items = append(child.items, mergeItem)
 		child.items = append(child.items, mergeChild.items...)
 		child.children = append(child.children, mergeChild.children...)


### PR DESCRIPTION
bug flow
new btree t1
clone btree t2
remove item and need merge i + 1 children.
now, i + 1 children has new cow, but no copy;
t1 modiyf i + 1 children item, t2 follow modify (bug happen).

fix:
when merge i + 1 children, copy it  