### PR TITLE
fix: sync remove item may changed clone btree; (i+1) children has new…

### DIFF
--- a/btree_generic.go
+++ b/btree_generic.go
@@ -462,7 +462,7 @@ func (n *node[T]) growChildAndRemove(i int, item T, minItems int, typ toRemove) 
 		child := n.mutableChild(i)
 		// merge with right child
 		mergeItem := n.items.removeAt(i)
-		mergeChild := n.children.removeAt(i + 1)
+		mergeChild := n.children.removeAt(i + 1).mutableFor(n.cow)
 		child.items = append(child.items, mergeItem)
 		child.items = append(child.items, mergeChild.items...)
 		child.children = append(child.children, mergeChild.children...)


### PR DESCRIPTION
… cow, but do not copy; btree to btree generic